### PR TITLE
mrc-4306 Screenshots workflow

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -8,8 +8,8 @@ jobs:
   screenshots:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - name: Run WODIN
@@ -21,5 +21,5 @@ jobs:
           npx playwright test
       - uses: actions/upload-artifact@v3
         with:
-          name: test-artifact
+          name: screenshots
           path: screenshot/screenshots/

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,16 @@
+name: screenshots
+on:
+  push:
+    branches:
+      - main
+      - mrc-4306
+jobs:
+  screenshots:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - name: Run WODIN
+        run: ./scripts/run-wodin

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -14,6 +14,11 @@ jobs:
           node-version: 16.x
       - name: Run WODIN
         run: ./scripts/run-wodin
+      - name: Run Playwright suite
+        run: |
+          cd screenshot
+          npm install -D @playwright/test && npx playwright install
+          npx playwright test
       - uses: actions/upload-artifact@v3
         with:
           name: test-artifact

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -14,3 +14,7 @@ jobs:
           node-version: 16.x
       - name: Run WODIN
         run: ./scripts/run-wodin
+      - uses: actions/upload-artifact@v3
+        with:
+          name: test-artifact
+          path: screenshot/screenshot.png

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -22,4 +22,4 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: test-artifact
-          path: screenshot/screenshot.png
+          path: screenshot/screenshots/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .idea
 files/flu/.DS_Store
 .DS_Store
+screenshot/package.json
+screenshot/package-lock.json
+screenshot/node_modules
 tmpConfig

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 .idea
 files/flu/.DS_Store
 .DS_Store
+screenshot/node_modules
 screenshot/package.json
 screenshot/package-lock.json
-screenshot/node_modules
+screenshot/screenshots
 tmpConfig

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-
+.idea
 files/flu/.DS_Store
 .DS_Store
+tmpConfig

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ screenshot/node_modules
 screenshot/package.json
 screenshot/package-lock.json
 screenshot/screenshots
+screenshot/test-results
 tmpConfig

--- a/README.md
+++ b/README.md
@@ -8,5 +8,3 @@ run these locally:
 1. Make playwright suite the local folder: `cd screenshot`
 1. Install Playwright: `npm install -D @playwright/test && npx playwright install`
 1. Run the tests: `npx playwright test`
-
-

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 ## Introduction to Mathematical Models of the Epidemiology & Control of Infectious Diseases
 
 For more information, see [infectiousdiseasemodels.org](http://www.infectiousdiseasemodels.org/) or [to the applications]()
+
+Automated screenshots are generated in a github workflow named `screenshots` which runs a suite of Playwright tests. To
+run these locally:
+1. Run WODIN with config: `./scripts/run-wodin`
+1. Make playwright suite the local folder: `cd screenshot`
+1. Install Playwright: `npm install -D @playwright/test && npx playwright install`
+1. Run the tests: `npx playwright test`
+
+

--- a/screenshot/basic.etest.ts
+++ b/screenshot/basic.etest.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import {takeScreenshot} from "./utils";
+import {takeScreenshot, waitForPlot} from "./utils";
 
 const folder = "basic";
 
@@ -8,7 +8,7 @@ test.beforeEach(async ({ page }) => {
 });
 
 test("Code and Run tabs", async ({ page }) => {
-    await expect(page.locator(":nth-match(.plot .main-svg, 1)")).toBeVisible(); // wait for the plot to render
+    await waitForPlot(page);
     await takeScreenshot(page, folder, "CodeRun");
 });
 

--- a/screenshot/basic.etest.ts
+++ b/screenshot/basic.etest.ts
@@ -1,4 +1,7 @@
 import { test, expect } from "@playwright/test";
+import {takeScreenshot} from "./utils";
+
+const folder = "basic";
 
 test.beforeEach(async ({ page }) => {
     await page.goto("/");
@@ -6,5 +9,5 @@ test.beforeEach(async ({ page }) => {
 
 test("initial", async ({ page }) => {
     expect(await page.innerText("h1")).toBe("Introduction to Mathematical Models of the Epidemiology & Control of Infectious Diseases - 2023");
-    await page.screenshot({ path: "screenshot.png" });
+    await takeScreenshot(page, folder, "test");
 });

--- a/screenshot/basic.etest.ts
+++ b/screenshot/basic.etest.ts
@@ -20,5 +20,11 @@ test("Options and Run tabs", async ({ page }) => {
 test("Options and Sensitivity tabs", async ({ page }) => {
     await page.click(":nth-match(.wodin-left .nav-link, 2)");
     await page.click(":nth-match(.wodin-right .nav-link, 2)");
+    // choose a parameter with more obvious effect on plot
+    await page.click("#sensitivity-options .btn-primary");
+    await page.locator("#edit-param-to-vary select").selectOption("R0");
+    await page.click("#edit-param .btn-primary"); //OK from dialog
+    await page.click("#run-sens-btn");
+    await expect(page.locator("#run-sens-btn")).toBeEnabled();
     await takeScreenshot(page, folder, "OptionsSensitivity");
 });

--- a/screenshot/basic.etest.ts
+++ b/screenshot/basic.etest.ts
@@ -6,4 +6,5 @@ test.beforeEach(async ({ page }) => {
 
 test("initial", async ({ page }) => {
     expect(await page.innerText("h1")).toBe("Introduction to Mathematical Models of the Epidemiology & Control of Infectious Diseases - 2023");
+    await page.screenshot({ path: "screenshot.png" });
 });

--- a/screenshot/basic.etest.ts
+++ b/screenshot/basic.etest.ts
@@ -8,11 +8,16 @@ test.beforeEach(async ({ page }) => {
 });
 
 test("Code and Run tabs", async ({ page }) => {
-    await expect(page.locator("reset-btn")).toBeEnabled(); // wait for code tab to fully load
+    await expect(page.locator("#reset-btn")).toBeEnabled(); // wait for code tab to fully load
     await takeScreenshot(page, folder, "CodeRun");
 });
 
 test("Options and Run tabs", async ({ page }) => {
     await page.click(":nth-match(.wodin-left .nav-link, 2)");
     await takeScreenshot(page, folder, "OptionsRun");
+});
+
+test("Options and Sensitivity tabs", async ({ page }) => {
+    await page.click(":nth-match(.wodin-left .nav-link, 2)");
+    await takeScreenshot(page, folder, "OptionsSensitivity");
 });

--- a/screenshot/basic.etest.ts
+++ b/screenshot/basic.etest.ts
@@ -8,6 +8,7 @@ test.beforeEach(async ({ page }) => {
 });
 
 test("Code and Run tabs", async ({ page }) => {
+    await expect(page.locator("reset-btn")).toBeEnabled(); // wait for code tab to fully load
     await takeScreenshot(page, folder, "CodeRun");
 });
 

--- a/screenshot/basic.etest.ts
+++ b/screenshot/basic.etest.ts
@@ -4,10 +4,14 @@ import {takeScreenshot} from "./utils";
 const folder = "basic";
 
 test.beforeEach(async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/apps/vaccination");
 });
 
-test("initial", async ({ page }) => {
-    expect(await page.innerText("h1")).toBe("Introduction to Mathematical Models of the Epidemiology & Control of Infectious Diseases - 2023");
-    await takeScreenshot(page, folder, "test");
+test("Code and Run tabs", async ({ page }) => {
+    await takeScreenshot(page, folder, "CodeRun");
+});
+
+test("Options and Run tabs", async ({ page }) => {
+    await page.click(":nth-match(.wodin-left .nav-link, 2)");
+    await takeScreenshot(page, folder, "OptionsRun");
 });

--- a/screenshot/basic.etest.ts
+++ b/screenshot/basic.etest.ts
@@ -8,7 +8,7 @@ test.beforeEach(async ({ page }) => {
 });
 
 test("Code and Run tabs", async ({ page }) => {
-    await expect(page.locator("#reset-btn")).toBeEnabled(); // wait for code tab to fully load
+    await expect(page.locator(":nth-match(.plot .main-svg, 1)")).toBeVisible(); // wait for the plot to render
     await takeScreenshot(page, folder, "CodeRun");
 });
 
@@ -19,5 +19,6 @@ test("Options and Run tabs", async ({ page }) => {
 
 test("Options and Sensitivity tabs", async ({ page }) => {
     await page.click(":nth-match(.wodin-left .nav-link, 2)");
+    await page.click(":nth-match(.wodin-right .nav-link, 2)");
     await takeScreenshot(page, folder, "OptionsSensitivity");
 });

--- a/screenshot/basic.etest.ts
+++ b/screenshot/basic.etest.ts
@@ -1,0 +1,9 @@
+import { test, expect } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+});
+
+test("initial", async ({ page }) => {
+    expect(await page.innerText("h1")).toBe("Introduction to Mathematical Models of the Epidemiology & Control of Infectious Diseases - 2023");
+});

--- a/screenshot/fit.etest.ts
+++ b/screenshot/fit.etest.ts
@@ -1,0 +1,34 @@
+import {test, expect, Page} from "@playwright/test";
+import {takeScreenshot} from "./utils";
+
+const folder = "fit";
+
+test.beforeEach(async ({ page }) => {
+    await page.goto("/apps/flu");
+});
+
+const uploadData = async (page: Page) => {
+    const filename = "../files/flu/influenza_data.csv";
+    await page.setInputFiles("#fitDataUpload", filename);
+};
+
+test("Data and Run tabs", async ({ page }) => {
+    await uploadData(page);
+    // wait for Run tab to update
+    await expect(page.locator(".wodin-plot-data-summary-series[name='Cases']")).toHaveCount(1);
+    await takeScreenshot(page, folder,"DataRun");
+});
+
+test("Options and Fit tabs", async ({ page }) => {
+    await uploadData(page);
+    await page.click(":nth-match(.wodin-left .nav-link, 3)");
+    await page.click(":nth-match(.wodin-right .nav-link, 2)");
+    await page.locator("#link-data select").selectOption("onset"); // link data to variable
+    // parameters to vary
+    await page.locator(":nth-match(#model-params .form-check-input, 1)").check();
+    await page.locator(":nth-match(#model-params .form-check-input, 3)").check();
+    await page.click("#fit-btn");
+    // wait for fit complete check
+    await expect(page.locator(".fit-tab i svg.feather-check")).toHaveCount(1);
+    await takeScreenshot(page, folder,"OptionsFit");
+});

--- a/screenshot/fit.etest.ts
+++ b/screenshot/fit.etest.ts
@@ -14,7 +14,7 @@ const uploadData = async (page: Page) => {
 
 test("Data and Run tabs", async ({ page }) => {
     await uploadData(page);
-    // wait for Run tab to update
+    // wait for Run tab to update with Cases series
     await expect(page.locator(".wodin-plot-data-summary-series[name='Cases']")).toHaveCount(1);
     await takeScreenshot(page, folder,"DataRun");
 });

--- a/screenshot/playwright.config.ts
+++ b/screenshot/playwright.config.ts
@@ -5,7 +5,8 @@ const config: PlaywrightTestConfig = {
     fullyParallel: true,
     use: {
         baseURL: "http://localhost:3000",
-        actionTimeout: 0
+        actionTimeout: 0,
+        viewport: { width: 1920, height: 1080 }
     }
 };
 

--- a/screenshot/playwright.config.ts
+++ b/screenshot/playwright.config.ts
@@ -1,0 +1,12 @@
+import type { PlaywrightTestConfig } from "@playwright/test";
+
+const config: PlaywrightTestConfig = {
+    testMatch: "*.etest.ts",
+    fullyParallel: true,
+    use: {
+        baseURL: "http://localhost:3000",
+        actionTimeout: 0
+    }
+};
+
+export default config;

--- a/screenshot/playwright.config.ts
+++ b/screenshot/playwright.config.ts
@@ -6,7 +6,8 @@ const config: PlaywrightTestConfig = {
     use: {
         baseURL: "http://localhost:3000",
         actionTimeout: 0,
-        viewport: { width: 1920, height: 1080 }
+        viewport: { width: 1920, height: 1080 },
+        screenshot: "only-on-failure"
     }
 };
 

--- a/screenshot/stochastic.etest.ts
+++ b/screenshot/stochastic.etest.ts
@@ -1,0 +1,21 @@
+import {test, expect, Page} from "@playwright/test";
+import {takeScreenshot, waitForPlot} from "./utils";
+
+const folder = "stochastic";
+
+test.beforeEach(async ({ page }) => {
+    await page.goto("/apps/stochasticity-3");
+});
+
+test("Code and Run tabs", async ({ page }) => {
+    await page.click(":nth-match(.wodin-right .nav-link, 2)");
+    await waitForPlot(page);
+    await takeScreenshot(page, folder, "CodeRun");
+});
+
+test("Options and Run tabs", async ({ page }) => {
+    await page.click(":nth-match(.wodin-left .nav-link, 2)");
+    await page.click(":nth-match(.wodin-right .nav-link, 2)");
+    await waitForPlot(page);
+    await takeScreenshot(page, folder, "OptionsRun");
+});

--- a/screenshot/utils.ts
+++ b/screenshot/utils.ts
@@ -1,0 +1,5 @@
+import { Page } from "@playwright/test";
+
+export const takeScreenshot = async (page: Page, folder: string, name: string) => {
+    await page.screenshot({ path: `screenshots/${folder}/${name}.png` });
+}

--- a/screenshot/utils.ts
+++ b/screenshot/utils.ts
@@ -1,5 +1,9 @@
-import { Page } from "@playwright/test";
+import {expect, Page} from "@playwright/test";
 
 export const takeScreenshot = async (page: Page, folder: string, name: string) => {
     await page.screenshot({ path: `screenshots/${folder}/${name}.png` });
-}
+};
+
+export const waitForPlot = async (page: Page) => {
+    await expect(page.locator(":nth-match(.plot .main-svg, 1)")).toBeVisible();
+};

--- a/scripts/run-wodin
+++ b/scripts/run-wodin
@@ -22,7 +22,3 @@ docker run -d --name redis --network=wodin-nw redis:6
 WODIN_TAG=mrcide/wodin:$WODIN_BRANCH
 docker pull $WODIN_TAG
 docker run -d --name wodin -p 3000:3000 --network=wodin-nw -v $TMP_CONFIG:/config:ro $WODIN_TAG /config
-
-# check the app is there - TODO: remove this when tests are implemented
-#sleep 5
-#curl --head --fail  http://localhost:3000

--- a/scripts/run-wodin
+++ b/scripts/run-wodin
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -ex
+
+# copy config and use local base url
+TMP_CONFIG=$PWD/tmpConfig
+rm -rf $TMP_CONFIG
+mkdir $TMP_CONFIG
+cp -r apps defaultCode files help index.html wodin.config.json $TMP_CONFIG
+sed -i 's+https://epimodels.dide.ic.ac.uk/shortcourse-2023+http://localhost:3000+g' $TMP_CONFIG/wodin.config.json
+
+WODIN_BRANCH=main
+ODIN_API_BRANCH=main
+
+docker network create wodin-nw
+
+ODIN_API_TAG=mrcide/odin.api:$ODIN_API_BRANCH
+docker pull $ODIN_API_TAG
+docker run -d --name odin.api --rm --network=wodin-nw $ODIN_API_TAG
+
+docker run -d --name redis --network=wodin-nw redis:6
+
+WODIN_TAG=mrcide/wodin:$WODIN_BRANCH
+docker pull $WODIN_TAG
+docker run -d --name wodin -p 3000:3000 --network=wodin-nw -v $TMP_CONFIG:/config:ro $WODIN_TAG /config
+
+# check the app is there
+curl --head --fail  http://localhost:3000

--- a/scripts/run-wodin
+++ b/scripts/run-wodin
@@ -23,6 +23,6 @@ WODIN_TAG=mrcide/wodin:$WODIN_BRANCH
 docker pull $WODIN_TAG
 docker run -d --name wodin -p 3000:3000 --network=wodin-nw -v $TMP_CONFIG:/config:ro $WODIN_TAG /config
 
-# check the app is there
+# check the app is there - TODO: remove this when tests are implemented
 sleep 5
 curl --head --fail  http://localhost:3000

--- a/scripts/run-wodin
+++ b/scripts/run-wodin
@@ -24,5 +24,5 @@ docker pull $WODIN_TAG
 docker run -d --name wodin -p 3000:3000 --network=wodin-nw -v $TMP_CONFIG:/config:ro $WODIN_TAG /config
 
 # check the app is there - TODO: remove this when tests are implemented
-sleep 5
-curl --head --fail  http://localhost:3000
+#sleep 5
+#curl --head --fail  http://localhost:3000

--- a/scripts/run-wodin
+++ b/scripts/run-wodin
@@ -24,4 +24,5 @@ docker pull $WODIN_TAG
 docker run -d --name wodin -p 3000:3000 --network=wodin-nw -v $TMP_CONFIG:/config:ro $WODIN_TAG /config
 
 # check the app is there
+sleep 5
 curl --head --fail  http://localhost:3000


### PR DESCRIPTION
This branch adds a suite of Playwright tests which takes screenshots of this WODIN configuration. The tests are run in a gha workflow, which uploads them as an artifact. Key changes:
- `run-wodin` script which runs wodin and dependencies. In order to get this working locally with the configuration, it copies only the required files into a tmp folder, and modifies the configured base url from https://epimodels.dide.ic.ac.uk/shortcourse-2023 to http://localhost:3000
- Playwright tests, in `screenshot` folder - this takes some screenshots of tabs displayed for basic, fit and stochastic apps, and saves them into separate folders. We can add more later if required. 
- gha action, which runs only on push to this branch or main, and which saves the screenshots folder as an artifact, which can be downloaded from the action run, e.g. https://github.com/mrc-ide/wodin-shortcourse-2023/actions/runs/5624091609

A couple of caveats:
- This config isn't finalised yet - the index page does not match the list of apps for which config is provided, so we'll probably have to update this for the finalised apps eventually. 
- On deployment, the full contents of this repo will be copied into the wodin container as config, including the tests. I don't think this should cause any problems but it would be cleaner if it didn't do this, so it might be worth refactoring so that the config repos are expected to keep config to be copied in a subfolder rather than the top level.